### PR TITLE
Changes to successfully run boot.pl and at least some examples on Mac OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.elf
 *.bin
 */bin/*
+boot/*.hex
+*.d

--- a/boot.pl
+++ b/boot.pl
@@ -4,7 +4,7 @@ use Device::SerialPort;
 use File::Basename;
 use lib dirname(__FILE__).'/tools/lib';
 use Time::HiRes qw|usleep|;
-use Linux::Termios2;
+use if ("$^O" ne "darwin"), "Linux::Termios2";
 use Time::HiRes;
 use POSIX qw( :termios_h );
 no utf8;

--- a/lib/libc.c
+++ b/lib/libc.c
@@ -1,6 +1,6 @@
 #include <stdint.h>
 #include <stdbool.h>
-#include <string.h>
+#include <stddef.h>
 
 void *memcpy(void *dest, const void *src, size_t len) {
 	char *d = dest;

--- a/lib/rules.mk
+++ b/lib/rules.mk
@@ -97,7 +97,7 @@ TGT_LDFLAGS += -Wl,--print-gc-sections
 endif
 
 #LDLIBS += -Wl,--start-group -lc_nano -lgcc -lnosys -Wl,--end-group
-LDLIBS += -Wl,--start-group -nostdlib -lgcc -lnosys -Wl,--end-group
+LDLIBS += -Wl,--start-group -nostdlib -lgcc -Wl,--end-group
 
 # Burn in legacy hell fortran modula pascal yacc idontevenwat
 .SUFFIXES:


### PR DESCRIPTION
My environment:
```
% arm-none-eabi-gcc -v

Using built-in specs.
COLLECT_GCC=arm-none-eabi-gcc
COLLECT_LTO_WRAPPER=/opt/homebrew/Cellar/arm-none-eabi-gcc/13.2.0/libexec/gcc/arm-none-eabi/13.2.0/lto-wrapper
Target: arm-none-eabi
Configured with: ../configure --target=arm-none-eabi --prefix=/opt/homebrew/Cellar/arm-none-eabi-gcc/13.2.0 --infodir=/opt/homebrew/Cellar/arm-none-eabi-gcc/13.2.0/share/info/arm-none-eabi --disable-nls --without-isl --without-headers --with-as=/opt/homebrew/opt/arm-none-eabi-binutils/bin/arm-none-eabi-as --with-ld=/opt/homebrew/opt/arm-none-eabi-binutils/bin/arm-none-eabi-ld --enable-languages=c,c++
Thread model: single
Supported LTO compression algorithms: zlib
gcc version 13.2.0 (GCC)

% uname -srm
Darwin 22.6.0 arm64

% perl -v

This is perl 5, version 36, subversion 1 (v5.36.1) built for darwin-thread-multi-2level
```